### PR TITLE
add option --password. Fix option --pwd-from-stdin.

### DIFF
--- a/bin/trocla
+++ b/bin/trocla
@@ -45,6 +45,9 @@ OptionParser.new do |opts|
     options[:ask_password] = false
   end
 
+  opts.on("--stdin", "Read data from STDIN") do
+    options[:ask_password] = false
+  end
 
 end.parse!
 


### PR DESCRIPTION
This pull is replacement of the old one https://github.com/duritong/trocla/pull/1.

`--pwd-from-stdin` now can read from STDIN.

You can use pipe to provide multiple line password. _Side effect:_ you can use trocla to store/retreive any kind of data, for example, public SSH key for your deployment tool. This is very useful :P For example:

```
cat /path/to/some/private/key | trocla set --pwd-from-stdin user1 plain
```

The former way of `--pwd-from-stdin` should be provided by the option `--password`. `STDIN` has a different mean, IMHO. To specify the password at command line, use `-p foobar`. When this option is used, `--pwd-from-file` will be ignored.
