### PR TITLE
Use camelize to create Format name.

### DIFF
--- a/lib/trocla/formats.rb
+++ b/lib/trocla/formats.rb
@@ -3,28 +3,28 @@ class Trocla::Formats
     def [](format)
       formats[format.downcase]
     end
-    
+
     def all
       Dir[File.expand_path(File.join(File.dirname(__FILE__),'formats','*.rb'))].collect{|f| File.basename(f,'.rb').downcase }
     end
-    
+
     def available?(format)
       all.include?(format.downcase)
     end
-    
+
     private
     def formats
       @@formats ||= Hash.new do |hash, format|
         format = format.downcase
         if File.exists?(path(format))
           require "trocla/formats/#{format}"
-          hash[format] = (eval "Trocla::Formats::#{format.capitalize}").new
+          hash[format] = (eval "Trocla::Formats::#{format.camelize}").new
         else
           raise "Format #{format} is not supported!"
         end
       end
     end
-    
+
     def path(format)
       File.expand_path(File.join(File.dirname(__FILE__),'formats',"#{format}.rb"))
     end

--- a/lib/trocla/util.rb
+++ b/lib/trocla/util.rb
@@ -22,3 +22,9 @@ class Trocla
     end
   end
 end
+
+class String
+  def camelize
+    self.split(/[^a-z0-9]/i).map{|w| w.capitalize}.join
+  end
+end


### PR DESCRIPTION
If there is format file foo_bar.rb, as usual the class name would be FooBar, not Foo_bar.
This patch will simply support the Camelize form.
