### PR TITLE
[BUG] Store hashed password supplied via 'set' instead of plaintext

### DIFF
--- a/bin/trocla
+++ b/bin/trocla
@@ -64,10 +64,11 @@ def set(options)
   else
     password = options.delete(:password) || STDIN.read.chomp
   end
+  format = options.delete(:trocla_format)
   Trocla.new(options.delete(:config_file)).set_password(
     options.delete(:trocla_key),
-    options.delete(:trocla_format),
-    password
+    format,
+    Trocla::Formats[format].format(password, options.delete(:other_options).shift.to_s)
   )
   ""
 end


### PR DESCRIPTION
Trocla doesn't save the hashed password in the data file, even if the
format passed to 'set' is not 'plain':

$ echo foobar | trocla set testuser sha512crypt -p

$ grep -A1 testuser trocla_data.yaml
testuser:
  sha512crypt: foobar
