### PR TITLE
shellsafe returns unsafe chars in 0.0.11

### DIFF
--- a/lib/trocla/util.rb
+++ b/lib/trocla/util.rb
@@ -19,7 +19,7 @@ class Trocla
         @chars ||= normal_chars + special_chars
       end
       def safechars
-        @chars ||= normal_chars + shellsafe_chars
+        @shellsafe ||= normal_chars + shellsafe_chars
       end
       def normal_chars
         @normal_chars ||= ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a


### PR DESCRIPTION
chars method was called before shellsafe method and @chars were initialized with characters which should never appear in shell. please issue 0.0.12 as this might be security related.

debug with print on charsets methods:

```
CHARS
SHELLSAFE
ALPHA
ALPHA
SHELLSAFE
CHARSET shellsafe ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "%", "/", "@", "=", "?", "_", ".", ",", ":", "*", "(", ")", "&", "!", "[", "]", "{", "}", "-"]
QR&AbAKSR=%9c{,+-N,0JD/6{=hxe!wZ9
QR&AbAKSR=%9c{,+-N,0JD/6{=hxe!wZ9
```
