### PR TITLE
ensure certificate validity is number

### DIFF
--- a/lib/trocla/formats/x509.rb
+++ b/lib/trocla/formats/x509.rb
@@ -21,7 +21,7 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     sign_with = options['ca'] || nil
     keysize = options['keysize'] || 2048
     serial = options['serial'] || 1
-    days = options['days'] || 365
+    days = options['days'].to_i || 365
     altnames = options['altnames'] || nil
     altnames.collect { |v| "DNS:#{v}" }.join(', ') if altnames
 


### PR DESCRIPTION
with "days" defined (other than default 365) it err'd with "can't convert String into an exact number".
it seems nobody is using it anyway, but let's make it work :D