### PR TITLE
update copyright years. now matching

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Trocla - a simple password generator and storage
-Copyright (C) 2011 Marcel Haerry
+Copyright (C) 2011-2015 Marcel Haerry
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -213,6 +213,6 @@ ssl_options:
 
 ## Copyright
 
-Copyright (c) 2015 mh. See LICENSE.txt for
+Copyright (c) 2011-2015 mh. See LICENSE.txt for
 further details.
 


### PR DESCRIPTION
I have seen that the two copyright years does not match. I have updated the years of copyright.

Could you please after then release a new version to rubygems? - I will package and upload your trocla into debian.

Thanks!