### PR TITLE
Fix self-signed certificate CA parameters.

### DIFF
--- a/lib/trocla/formats/x509.rb
+++ b/lib/trocla/formats/x509.rb
@@ -117,9 +117,10 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     ef.subject_certificate = cert
     ef.issuer_certificate = issuer
     cert.extensions = [ ef.create_extension("subjectKeyIdentifier", "hash") ]
-    cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true) if subject == issuer
-    cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true) if subject != issuer
-    cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true)
+    cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true) if cert.subject == cert.issuer
+    cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true) if cert.subject != cert.issuer
+    cert.add_extension ef.create_extension("keyUsage", "keyCertSign, cRLSign, nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject == cert.issuer
+    cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject != cert.issuer
     cert.add_extension ef.create_extension("subjectAltName", altnames, true) if altnames
     cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
 


### PR DESCRIPTION
Hi,

Self-signed certificates were unable to pass an `openssl verify` because `issuer` and `subject` were tested instead of `cert.issuer` and `cert.subject`, thus CA was never set to TRUE.

I also added keyCertSign and cRLSign usages to self-signed certificates.

Sincerely,
Adrien