### PR TITLE
Fix x509, add tests & change default behavior in regards of being a CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ ssl_options:
 
 ## Update & Changes
 
+### to 0.1.3
+
+1. CHANGE: Self signed certificates are no longer CAs by default, actually they have never been due to a bug. If you want that a certificate is also a CA, you *must* pass `become_ca: true` to the options hash. But this makes it actually possible, that you can even have certificate chains. Thanks for initial hint to [Adrien Bréfort](https://github.com/abrefort)
+1. Fixing setting of altnames, was not possible due to bug, till now.
+1. Add extended tests for the x509 format, that describe all the internal specialities and should give an idea how it can be used.
+
 ### to 0.1.1
 
 1. fix storing data longer that public Keysize -11. Thanks [Timo Goebel](https://github.com/timogoebel)

--- a/lib/trocla/formats/x509.rb
+++ b/lib/trocla/formats/x509.rb
@@ -18,16 +18,21 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
       raise "You need to pass \"subject\" or \"CN\" as an option to use this format"
     end
     hash = options['hash'] || 'sha2'
-    sign_with = options['ca'] || nil
+    sign_with = options['ca']
+    become_ca = options['become_ca'] || false
     keysize = options['keysize'] || 2048
     serial = options['serial'] || 1
     days = options['days'].to_i || 365
-    altnames = options['altnames'] || nil
-    altnames.collect { |v| "DNS:#{v}" }.join(', ') if altnames
+    if an = options['altnames']
+      altnames = an.collect { |v| "DNS:#{v}" }.join(', ')
+    else
+      altnames = nil
+    end
 
     begin
       key = mkkey(keysize)
     rescue Exception => e
+      puts e.backtrace
       raise "Private key for #{subject} creation failed: #{e.message}"
     end
 
@@ -49,7 +54,7 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
       end
 
       begin
-        csr_cert = mkcert(caserial, request.subject, ca, request.public_key, days, altnames)
+        csr_cert = mkcert(caserial, request.subject, ca, request.public_key, days, altnames, become_ca)
         csr_cert.sign(cakey, signature(hash))
         setserial(sign_with, caserial)
       rescue Exception => e
@@ -60,7 +65,7 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     else # self-signed certificate
       begin
         subj = OpenSSL::X509::Name.parse(subject)
-        cert = mkcert(serial, subj, nil, key.public_key, days, altnames)
+        cert = mkcert(serial, subj, nil, key.public_key, days, altnames, become_ca)
         cert.sign(key, signature(hash))
       rescue Exception => e
         raise "Self-signed certificate #{subject} creation failed: #{e.message}"
@@ -102,7 +107,7 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     request
   end
 
-  def mkcert(serial,subject,issuer,public_key,days,altnames)
+  def mkcert(serial,subject,issuer,public_key,days,altnames, become_ca = false)
     cert = OpenSSL::X509::Certificate.new
     issuer = cert if issuer == nil
     cert.subject = subject
@@ -117,10 +122,14 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     ef.subject_certificate = cert
     ef.issuer_certificate = issuer
     cert.extensions = [ ef.create_extension("subjectKeyIdentifier", "hash") ]
-    cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true) if cert.subject == cert.issuer
-    cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true) if cert.subject != cert.issuer
-    cert.add_extension ef.create_extension("keyUsage", "keyCertSign, cRLSign, nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject == cert.issuer
-    cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject != cert.issuer
+
+    if become_ca
+      cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true)
+      cert.add_extension ef.create_extension("keyUsage", "keyCertSign, cRLSign, nonRepudiation, digitalSignature, keyEncipherment", true)
+    else
+      cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true)
+      cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true)
+    end
     cert.add_extension ef.create_extension("subjectAltName", altnames, true) if altnames
     cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
 

--- a/lib/trocla/formats/x509.rb
+++ b/lib/trocla/formats/x509.rb
@@ -117,9 +117,10 @@ class Trocla::Formats::X509 < Trocla::Formats::Base
     ef.subject_certificate = cert
     ef.issuer_certificate = issuer
     cert.extensions = [ ef.create_extension("subjectKeyIdentifier", "hash") ]
-    cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true) if subject == issuer
-    cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true) if subject != issuer
-    cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true)
+    cert.add_extension ef.create_extension("basicConstraints","CA:TRUE", true) if cert.subject == cert.issuer
+    cert.add_extension ef.create_extension("basicConstraints","CA:FALSE", true) if cert.subject != cert.issuer
+    cert.add_extension ef.create_extension("keyUsage", "keyCertSign, cRLSign, nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject == cert.issuer
+    cert.add_extension ef.create_extension("keyUsage", "nonRepudiation, digitalSignature, keyEncipherment", true) if cert.subject != cert.issuer
     cert.add_extension ef.create_extension("subjectAltName", altnames, true) if altnames
     cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,16 @@ def test_config
   @config
 end
 
+def test_config_persistent
+  return @config unless @config.nil?
+  @config = default_config
+  @config['adapter'] = :YAML
+  @config['adapter_options'] = {
+    :file => trocla_yaml_file
+  }
+  @config
+end
+
 def ssl_test_config
   return @ssl_config unless @ssl_config.nil?
   @ssl_config = test_config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require 'trocla'
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  
+
 end
 
 def default_config

--- a/spec/trocla/encryptions/none_spec.rb
+++ b/spec/trocla/encryptions/none_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe "Trocla::Encryptions::None" do
+
+  before(:each) do
+    expect_any_instance_of(Trocla).to receive(:read_config).and_return(test_config_persistent)
+    @trocla = Trocla.new
+  end
+
+  after(:each) do
+    remove_yaml_store
+  end
+
+  describe "none" do
+    it "should be able to store random passwords" do
+      @trocla.password('random1', 'plain').length.should eql(12)
+    end
+
+    it "should be able to store long random passwords" do
+      @trocla.set_password('random1_long','plain',4096.times.collect{|s| 'x' }.join('')).length.should eql(4096)
+    end
+
+    it "should be able to retrieve stored unencrypted passwords" do
+      stored = @trocla.password('random1', 'plain')
+      retrieved = @trocla.password('random1', 'plain')
+      retrieved_again = @trocla.password('random1', 'plain')
+      retrieved.should eql(stored)
+      retrieved_again.should eql(stored)
+    end
+
+    it "should be able to read unencrypted passwords" do
+      @trocla.set_password('some_pass', 'plain', 'super secret')
+      @trocla.get_password('some_pass', 'plain').should eql('super secret')
+    end
+
+    it "should store plaintext passwords" do
+      @trocla.set_password('noplain', 'plain', 'plaintext_password')
+      File.readlines(trocla_yaml_file).grep(/plaintext_password/).should eql(["  plain: plaintext_password\n"])
+    end
+  end
+end

--- a/spec/trocla/formats/x509_spec.rb
+++ b/spec/trocla/formats/x509_spec.rb
@@ -1,0 +1,151 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require 'date'
+
+describe "Trocla::Format::X509" do
+
+  before(:each) do
+    expect_any_instance_of(Trocla).to receive(:read_config).and_return(test_config)
+    @trocla = Trocla.new
+  end
+
+  let(:ca_options) do
+    {
+      'CN'        => 'This is my self-signed certificate which doubles as CA',
+      'become_ca' => true,
+    }
+  end
+  let(:cert_options) do
+    {
+      'ca'       => 'my_shiny_selfsigned_ca',
+      'subject'  => '/C=ZZ/O=Trocla Inc./CN=test/emailAddress=example@example.com',
+    }
+  end
+
+  describe "x509 selfsigned" do
+    it "should be able to create self signed cert without being a ca by default" do
+      ca_str = @trocla.password('my_shiny_selfsigned_ca', 'x509', {
+        'CN'        => 'This is my self-signed certificate',
+        'become_ca' => false,
+      })
+      ca = OpenSSL::X509::Certificate.new(ca_str)
+      # selfsigned?
+      ca.issuer.should eql(ca.subject)
+
+      ca.extensions.find{|e| e.oid == 'basicConstraints' }.value.should eql('CA:FALSE')
+      ku = ca.extensions.find{|e| e.oid == 'keyUsage' }.value
+      ku.should_not match(/Certificate Sign/)
+      ku.should_not match(/CRL Sign/)
+    end
+
+    it "should be able to create a self signed cert that is a CA" do
+      ca_str = @trocla.password('my_shiny_selfsigned_ca', 'x509', ca_options)
+      ca = OpenSSL::X509::Certificate.new(ca_str)
+      # selfsigned?
+      ca.issuer.should eql(ca.subject)
+
+      ca.extensions.find{|e| e.oid == 'basicConstraints' }.value.should eql('CA:TRUE')
+      ku = ca.extensions.find{|e| e.oid == 'keyUsage' }.value
+      ku.should match(/Certificate Sign/)
+      ku.should match(/CRL Sign/)
+    end
+
+  end
+  describe "x509 signed by a ca" do
+    before(:each) do
+      ca_str = @trocla.password('my_shiny_selfsigned_ca', 'x509', ca_options)
+      @ca = OpenSSL::X509::Certificate.new(ca_str)
+    end
+    it 'shold be able to get a cert signed by the ca' do
+      cert_str = @trocla.password('mycert', 'x509', cert_options)
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+      cert.issuer.should eql(@ca.subject)
+
+      cert.extensions.find{|e| e.oid == 'basicConstraints' }.value.should eql('CA:FALSE')
+      ku = cert.extensions.find{|e| e.oid == 'keyUsage' }.value
+      ku.should_not match(/Certificate Sign/)
+      ku.should_not match(/CRL Sign/)
+    end
+
+    it 'shold be able to get a cert signed by the ca that is again a ca' do
+      cert_str = @trocla.password('mycert', 'x509', cert_options.merge({
+        'become_ca' => true,
+      }))
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+      cert.issuer.should eql(@ca.subject)
+
+      cert.extensions.find{|e| e.oid == 'basicConstraints' }.value.should eql('CA:TRUE')
+      ku = cert.extensions.find{|e| e.oid == 'keyUsage' }.value
+      ku.should match(/Certificate Sign/)
+      ku.should match(/CRL Sign/)
+    end
+
+    it 'shold be able to get a cert signed by the ca that is again a ca that is able to sign certs' do
+      cert_str = @trocla.password('mycert_and_ca', 'x509', cert_options.merge({
+        'become_ca' => true,
+      }))
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+      cert.issuer.should eql(@ca.subject)
+
+      cert2_str = @trocla.password('mycert', 'x509', {
+        'ca'        => 'mycert_and_ca',
+        'subject'   => '/C=ZZ/O=Trocla Inc./CN=test2/emailAddress=example@example.com',
+        'become_ca' => true,
+      })
+      cert2 = OpenSSL::X509::Certificate.new(cert2_str)
+      cert2.issuer.should eql(cert.subject)
+    end
+
+    it 'should respect all options' do
+      co = cert_options.merge({
+        'hash'         => 'sha1',
+        'keysize'      => 4096,
+        'serial'       => 123456789,
+        'days'         => 3650,
+        'subject'      => nil,
+        'C'            => 'AA',
+        'ST'           => 'Earth',
+        'L'            => 'Here',
+        'O'            => 'SSLTrocla',
+        'OU'           => 'root',
+        'CN'           => 'www.test',
+        'emailAddress' => 'test@example.com',
+        'altnames'     => [ 'test', 'test1', 'test2', 'test3' ],
+      })
+      cert_str = @trocla.password('mycert', 'x509', co)
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+      cert.issuer.should eql(@ca.subject)
+      ['C','ST','L','O','OU','CN','emailAddress'].each do |field|
+        cert.subject.to_s.should match(/#{field}=#{co[field]}/)
+      end
+      cert.signature_algorithm.should eql('sha1WithRSAEncryption')
+      cert.serial.should eql(123456789)
+      cert.not_before.should < Time.now
+      Date.parse(cert.not_after.to_s) == Date.parse((Time.now+3650*24*60*60).to_s)
+      # https://stackoverflow.com/questions/13747212/determine-key-size-from-public-key-pem-format
+      (cert.public_key.n.num_bytes * 8).should eql(4096)
+      cert.extensions.find{|e| e.oid == 'subjectAltName' }.value.should eql('DNS:test, DNS:test1, DNS:test2, DNS:test3')
+
+      cert.extensions.find{|e| e.oid == 'basicConstraints' }.value.should eql('CA:FALSE')
+      ku = cert.extensions.find{|e| e.oid == 'keyUsage' }.value
+      ku.should_not match(/Certificate Sign/)
+      ku.should_not match(/CRL Sign/)
+    end
+
+    it 'should prefer full subject of single subject parts' do
+      co = cert_options.merge({
+        'C'            => 'AA',
+        'ST'           => 'Earth',
+        'L'            => 'Here',
+        'O'            => 'SSLTrocla',
+        'OU'           => 'root',
+        'CN'           => 'www.test',
+        'emailAddress' => 'test@example.com',
+      })
+      cert_str = @trocla.password('mycert', 'x509', co)
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+      ['C','ST','L','O','OU','CN','emailAddress'].each do |field|
+        cert.subject.to_s.should_not match(/#{field}=#{co[field]}/)
+      end
+    end
+  end
+end

--- a/spec/trocla_spec.rb
+++ b/spec/trocla_spec.rb
@@ -1,12 +1,12 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "Trocla" do
-  
+
   before(:each) do
     expect_any_instance_of(Trocla).to receive(:read_config).and_return(test_config)
     @trocla = Trocla.new
   end
-  
+
   describe "password" do
     it "should generate random passwords by default" do
       @trocla.password('random1','plain').should_not eql(@trocla.password('random2','plain'))
@@ -15,18 +15,18 @@ describe "Trocla" do
     it "should generate passwords of length #{default_config['options']['length']}" do
       @trocla.password('random1','plain').length.should eql(default_config['options']['length'])
     end
-    
+
     Trocla::Formats.all.each do |format|
       describe "#{format} password format" do
         it "should return a password hashed in the #{format} format" do
           @trocla.password('some_test',format,format_options[format]).should_not be_empty
         end
-        
+
         it "should return the same hashed for the #{format} format on multiple invocations" do
           (round1=@trocla.password('some_test',format,format_options[format])).should_not be_empty
           @trocla.password('some_test',format,format_options[format]).should eql(round1)
         end
-        
+
         it "should also store the plain password by default" do
           pwd = @trocla.password('some_test','plain')
           pwd.should_not be_empty
@@ -34,91 +34,91 @@ describe "Trocla" do
         end
       end
     end
-    
+
     Trocla::Formats.all.reject{|f| f == 'plain' }.each do |format|
       it "should raise an exception if not a random password is asked but plain password is not present for format #{format}" do
         lambda{ @trocla.password('not_random',format, 'random' => false) }.should raise_error
       end
     end
   end
-  
+
   describe "set_password" do
     it "should reset hashed passwords on a new plain password" do
       @trocla.password('set_test','mysql').should_not be_empty
       @trocla.get_password('set_test','mysql').should_not be_nil
       (old_plain=@trocla.password('set_test','mysql')).should_not be_empty
-      
+
       @trocla.set_password('set_test','plain','foobar').should_not eql(old_plain)
       @trocla.get_password('set_test','mysql').should be_nil
     end
-    
+
     it "should otherwise only update the hash" do
       (mysql = @trocla.password('set_test2','mysql')).should_not be_empty
       (md5crypt = @trocla.password('set_test2','md5crypt')).should_not be_empty
       (plain = @trocla.get_password('set_test2','plain')).should_not be_empty
-      
+
       (new_mysql = @trocla.set_password('set_test2','mysql','foo')).should_not eql(mysql)
       @trocla.get_password('set_test2','mysql').should eql(new_mysql)
       @trocla.get_password('set_test2','md5crypt').should eql(md5crypt)
       @trocla.get_password('set_test2','plain').should eql(plain)
     end
   end
-  
+
   describe "reset_password" do
     it "should reset a password" do
       plain1 = @trocla.password('reset_pwd','plain')
       plain2 = @trocla.reset_password('reset_pwd','plain')
-      
+
       plain1.should_not eql(plain2)
     end
-    
+
     it "should not reset other formats" do
       (mysql = @trocla.password('reset_pwd2','mysql')).should_not be_empty
       (md5crypt1 = @trocla.password('reset_pwd2','md5crypt')).should_not be_empty
-      
+
       (md5crypt2 = @trocla.reset_password('reset_pwd2','md5crypt')).should_not be_empty
       md5crypt2.should_not eql(md5crypt1)
-      
+
       @trocla.get_password('reset_pwd2','mysql').should eql(mysql)
     end
   end
-  
+
   describe "delete_password" do
     it "should delete all passwords if no format is given" do
       @trocla.password('delete_test1','mysql').should_not be_nil
       @trocla.get_password('delete_test1','plain').should_not be_nil
-      
+
       @trocla.delete_password('delete_test1')
       @trocla.get_password('delete_test1','plain').should be_nil
       @trocla.get_password('delete_test1','mysql').should be_nil
     end
-    
+
     it "should delete only a given format" do
       @trocla.password('delete_test2','mysql').should_not be_nil
       @trocla.get_password('delete_test2','plain').should_not be_nil
-      
+
       @trocla.delete_password('delete_test2','plain')
       @trocla.get_password('delete_test2','plain').should be_nil
       @trocla.get_password('delete_test2','mysql').should_not be_nil
     end
-    
+
     it "should delete only a given non-plain format" do
       @trocla.password('delete_test3','mysql').should_not be_nil
       @trocla.get_password('delete_test3','plain').should_not be_nil
-      
+
       @trocla.delete_password('delete_test3','mysql')
       @trocla.get_password('delete_test3','mysql').should be_nil
       @trocla.get_password('delete_test3','plain').should_not be_nil
     end
   end
-  
+
   def format_options
     @format_options ||= Hash.new({}).merge({
       'pgsql' => { 'username' => 'test' },
       'x509'  => { 'CN' => 'test' },
     })
   end
-  
+
 end
 
 describe "VERSION" do


### PR DESCRIPTION
So #31 was pointing to a bug, which meant that we never had CAs by default.

So I looked more detailed into the x509 format and started adding tests for it to better understand it.

Additionally, I added a few more options and in progress of that I decided to simply drop the intended default behavior and rather make it an option, that a certificate can also become a CA.

Certainly, there is room for more improvement (e.g. adding more extensions over options), nevertheless I think there is now also some kind of infrastructure to describe what we expect the extended functionality of the x509 format to be.

Given, that this still changes the supposed default behavior I would like to give @asquel, @abrefort and whoever think they should raise their voice some time to do it. Otherwise I will cut a new release.