### PR TITLE
Add a .open() method to auto close Trocla store after you're done

### DIFF
--- a/lib/trocla.rb
+++ b/lib/trocla.rb
@@ -13,6 +13,17 @@ class Trocla
     end
   end
 
+  def self.open(config_file=nil)
+    trocla = Trocla.new(config_file)
+
+    if block_given?
+      yield trocla
+      trocla.close
+    else
+      trocla
+    end
+  end
+
   def password(key,format,options={})
     # respect a default profile, but let the
     # profiles win over the default options
@@ -76,6 +87,10 @@ class Trocla
 
   def config
     @config ||= read_config
+  end
+
+  def close
+    store.close
   end
 
   private

--- a/lib/trocla/store.rb
+++ b/lib/trocla/store.rb
@@ -6,6 +6,12 @@ class Trocla::Store
     @trocla = trocla
   end
 
+  # closes the store
+  # when called do whatever "closes" your
+  # store, e.g. close database connections.
+  def close
+  end
+
   # should return value for key & format
   # returns nil if nothing or a nil value
   # was found.

--- a/lib/trocla/stores/moneta.rb
+++ b/lib/trocla/stores/moneta.rb
@@ -10,6 +10,10 @@ class Trocla::Stores::Moneta < Trocla::Store
     @moneta = Moneta.new(store_config['adapter'],adapter_options)
   end
 
+  def close
+    moneta.close
+  end
+
   def get(key,format)
     moneta.fetch(key, {})[format]
   end


### PR DESCRIPTION
This PR adds a .open() (similar to Ruby's File.open) method to automatically close the Trocla store after you're done with it.
We use trocla with mysql as backend for moneta and had massive problems with connection leaks especially if the process using trocla is not terminating quickly. In our case we use the trocla Puppet functions and this led to so many open but no longer used connections to our mysql database that after some short time it stopped working altogether.
Every call to Trocla.new causes moneta to open a new database connection but trocla never closes any of them explicitly, i.e. calls the moneta close method. The only way the connections got closed is on process termination as the os then cleans up all used sockets.
I think this issue over at moneta (https://github.com/minad/moneta/issues/85) is a direct consequence.
I'll submit a separate PR for the puppet functions that they use this new feature.