### PR TITLE
Fix #39 and commit 2f14f10

### DIFF
--- a/bin/trocla
+++ b/bin/trocla
@@ -79,7 +79,7 @@ def set(options)
   value = if no_format
     password
   else
-    trocla.formats(format).format(password, (YAML.load(options.delete(:other_options).shift.to_s)||''))
+    trocla.formats(format).format(password, (YAML.load(options.delete(:other_options).shift.to_s)||{}))
   end
   trocla.set_password(
     options.delete(:trocla_key),

--- a/bin/trocla
+++ b/bin/trocla
@@ -57,7 +57,7 @@ end
 def get(options)
   Trocla.new(options.delete(:config_file)).get_password(
     options.delete(:trocla_key),
-    options.delete(:trocla_format)
+    options.delete(:trocla_format),
     options.merge(YAML.load(options.delete(:other_options).shift.to_s)||{})
   )
 end
@@ -79,7 +79,7 @@ def set(options)
   value = if no_format
     password
   else
-    trocla.formats(format).format(password, options.delete(:other_options).shift.to_s)
+    trocla.formats(format).format(password, (YAML.load(options.delete(:other_options).shift.to_s)||''))
   end
   trocla.set_password(
     options.delete(:trocla_key),


### PR DESCRIPTION
Hello,

Fix #39 and #46 for set password with pgsql format, and correct commit 2f14f10

```BASH
~ # trocla create burps_password plain
D:KLGnN76*@du.%8
~ # trocla create burps_password pgsql "username: burps"
md52df5340723d08f62dbecef2d6dee4a22
~ # trocla delete burps_password pgsql
md52df5340723d08f62dbecef2d6dee4a22
~ # trocla set burps_password pgsql "username: burps"
Enter your password: xxxxxxxxxxxxxxxx
Repeat password: xxxxxxxxxxxxxxxx

~ # trocla get burps_password pgsql
md52df5340723d08f62dbecef2d6dee4a22
```
