### PR TITLE
expand search path for sample config file to fix autopkgtest

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -226,14 +226,13 @@ RSpec.shared_examples 'store_validation' do |store|
 end
 
 def default_config
-  config_path = false
-  for p in [
-          File.expand_path(base_dir+'/lib/trocla/default_config.yaml'),
-          File.expand_path(File.dirname($LOADED_FEATURES.grep(/trocla.rb/)[0])+'/trocla/default_config.yaml'),
-        ] do
-    config_path = p if File.exists?(p)
+  @default_config ||=  begin
+    config_path = [
+      File.expand_path(base_dir+'/lib/trocla/default_config.yaml'),
+      File.expand_path(File.dirname($LOADED_FEATURES.grep(/trocla.rb/)[0])+'/trocla/default_config.yaml'),
+    ].find { |p| File.exists?(p) }
+    YAML.load(File.read(config_path))
   end
-  @default_config ||= YAML.load(File.read(config_path))
 end
 
 def test_config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -226,7 +226,14 @@ RSpec.shared_examples 'store_validation' do |store|
 end
 
 def default_config
-  @default_config ||= YAML.load(File.read(File.expand_path(base_dir+'/lib/trocla/default_config.yaml')))
+  config_path = false
+  for p in [
+          File.expand_path(base_dir+'/lib/trocla/default_config.yaml'),
+          File.expand_path(File.dirname($LOADED_FEATURES.grep(/trocla.rb/)[0])+'/trocla/default_config.yaml'),
+        ] do
+    config_path = p if File.exists?(p)
+  end
+  @default_config ||= YAML.load(File.read(config_path))
 end
 
 def test_config


### PR DESCRIPTION
This fixes the Debian CI tests issue as described in:

https://bugs.debian.org/830240

The problem with the Debian CI infrastructure is that it deliberately
removes the `lib` tree from the source to make sure the *installed*
libraries are tested. This, obviously, fails in the current code base
as the default config file cannot be found.

This code is unlikely to be idiomatic Ruby, and I would be happy to
see a better version. But it does seem to fix the test suite in CI
while still allowing the test suite to run correctly at build time.