### PR TITLE
Add wireguard format to trocla

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ Output render options are:
     pubonly     If set to true the sshkey format will return only the ssh public key
     privonly    If set to true the sshkey format will return only the ssh private key
 
+### wireguard
+
+This format generate a keypair for WireGuard.
+
+The format requires the wg binary from WireGuard userland utilities.
+
+Output render options are:
+
+    pubonly     If set to true the wireguard format will return only the public key
+    privonly    If set to true the wireguard format will return only the private key
+
 ## Installation
 
 * Debian has trocla within its sid-release: `apt-get install trocla`

--- a/lib/trocla/formats/wireguard.rb
+++ b/lib/trocla/formats/wireguard.rb
@@ -1,0 +1,49 @@
+require 'open3'
+require 'yaml'
+
+class Trocla::Formats::Wireguard < Trocla::Formats::Base
+  expensive true
+
+  def format(plain_password, options={})
+    if plain_password.match(/---/)
+      return YAML.load(plain_password)
+    end
+    wg_priv = nil
+    wg_pub = nil 
+    begin
+      Open3.popen3('wg genkey') do |stdin, stdout, stderr, waiter|
+        wg_priv = stdout.read.chomp
+      end
+    rescue SystemCallError => e
+      if e.message =~ /No such file or directory/
+        raise "trocla wireguard: wg binary not found"
+      else
+        raise "trocla wireguard: #{e.message}"
+      end
+    end
+
+    begin
+      Open3.popen3('wg pubkey') do |stdin, stdout, stderr, waiter|
+        stdin.write(wg_priv)
+        stdin.close
+
+        wg_pub = stdout.read.chomp
+      end
+    rescue SystemCallError => e
+      raise "trocla wireguard: #{e.message}"
+    end
+    return YAML.dump({'wg_priv' => wg_priv, 'wg_pub' => wg_pub})
+  end
+
+  def render(output, render_options={})
+    data = YAML.load(output)
+    if render_options['privonly']
+      return data['wg_priv']
+    elsif render_options['pubonly']
+      return data['wg_pub']
+    else
+      return "pub: " + data['wg_pub'] + "\npriv: " + data['wg_priv'] 
+    end
+  end
+end
+


### PR DESCRIPTION
add format to generate WireGuard public and private keys and store it into trocla. 
the wg binary needs to be present on the trocla (puppetserver) to generate a keypair. it uses YAML to store the pub and private key into trocla