### PR TITLE
add missing method search for vault backend

### DIFF
--- a/lib/trocla/stores/vault.rb
+++ b/lib/trocla/stores/vault.rb
@@ -20,6 +20,10 @@ class Trocla::Stores::Vault < Trocla::Store
     read(key).keys
   end
 
+  def search(key)
+    vault.kv(mount).list(key)
+  end
+
   private
   def read(key)
     k = vault.kv(mount).read(key)


### PR DESCRIPTION
Hello,

We changed with 0.4.0, and saw that I was missing reporting the search method for the vault backend.

Regards,