### PR TITLE
add SCRAM-SHA-256 postgres support and ruby 2.5.7 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+---
 language: ruby
 sudo: false
 rvm:
   - jruby
+  - 2.5.7
   - 2.7.0
   - 3.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,24 @@
-source "http://rubygems.org"
+source 'http://rubygems.org'
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 
-gem "moneta", "~> 1.4.0"
-gem "highline", "~> 2.0.0"
+gem 'highline', '~> 2.0.0'
+gem 'moneta', '~> 1.4.0'
 
 if defined?(RUBY_ENGINE) && (RUBY_ENGINE == 'jruby')
   gem 'jruby-openssl'
 end
-gem "bcrypt"
-gem "sshkey"
+gem 'bcrypt'
+gem 'openssl'
+gem 'sshkey'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
-  gem "rspec"
-  gem "rdoc"
-  gem "jeweler"
-  gem "addressable"
+  gem 'addressable'
+  gem 'jeweler'
+  gem 'rdoc'
+  gem 'rspec'
   gem 'rspec-pending_for'
 end

--- a/README.md
+++ b/README.md
@@ -165,8 +165,9 @@ options to work properly. These are documented here:
 
 ### pgsql
 
-Password hashes for PostgreSQL servers. Requires the option `username` to be set
-to the username to which the password will be assigned.
+Password hashes for PostgreSQL servers. Since postgesql 10 you can use the sha256 hash, you have two options:
+* Create a ssh256 hash password with option `encode: sha256` (default value)
+* Create a md5 hash, the username is require for the salt key, with option  `encode: md5` and `username: your_user`
 
 ### bcrypt
 

--- a/lib/trocla/formats/pgsql.rb
+++ b/lib/trocla/formats/pgsql.rb
@@ -1,7 +1,53 @@
 class Trocla::Formats::Pgsql < Trocla::Formats::Base
   require 'digest/md5'
-  def format(plain_password,options={})
-    raise "You need pass the username as an option to use this format" unless options['username'] 
-    "md5" + Digest::MD5.hexdigest(plain_password + options['username'])
+  require 'openssl'
+  require 'base64'
+  def format(plain_password, options = {})
+    encode = (options['encode'] || 'sha256')
+    case encode
+    when 'md5'
+      raise 'You need pass the username as an option to use this format' unless options['username']
+      'md5' + Digest::MD5.hexdigest(plain_password + options['username'])
+    when 'sha256'
+      pg_sha256(plain_password)
+    else
+      raise 'Unkmow encode %s for pgsql password' % [encode]
+    end
+  end
+
+  private
+
+  def pg_sha256(password)
+    salt = OpenSSL::Random.random_bytes(16)
+    digest = digest_key(password, salt)
+    'SCRAM-SHA-256$%s:%s$%s:%s' % [
+      '4096',
+      Base64.strict_encode64(salt),
+      Base64.strict_encode64(client_key(digest)),
+      Base64.strict_encode64(server_key(digest))
+    ]
+  end
+
+  def digest_key(password, salt)
+    OpenSSL::KDF.pbkdf2_hmac(
+      password,
+      salt: salt,
+      iterations: 4096,
+      length: 32,
+      hash: OpenSSL::Digest::SHA256.new
+    )
+  end
+
+  def client_key(digest_key)
+    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
+    hmac << 'Client Key'
+    hmac.digest
+    OpenSSL::Digest.new('SHA256').digest hmac.digest
+  end
+
+  def server_key(digest_key)
+    hmac = OpenSSL::HMAC.new(digest_key, OpenSSL::Digest::SHA256.new)
+    hmac << 'Server Key'
+    hmac.digest
   end
 end

--- a/spec/trocla/formats/pgsql_spec.rb
+++ b/spec/trocla/formats/pgsql_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+
+describe 'Trocla::Format::Pgsql' do
+  before(:each) do
+    expect_any_instance_of(Trocla).to receive(:read_config).and_return(test_config)
+    @trocla = Trocla.new
+  end
+
+  describe 'default pgsql' do
+    it 'create a pgsql password keypair without options in sha256' do
+      pass = @trocla.password('pgsql_password_sh256', 'pgsql', {})
+      expect(pass).to match(/^SCRAM-SHA-256\$(.*):(.*)\$(.*):/)
+    end
+  end
+
+  describe 'pgsql in md5 encode' do
+    it 'create a pgsql password in md5 encode' do
+      pass = @trocla.password(
+        'pgsql_password_md5', 'pgsql',
+        { 'username' => 'toto', 'encode' => 'md5' }
+      )
+      expect(pass).to match(/^md5/)
+    end
+  end
+end


### PR DESCRIPTION
Hello,

Since pg 10 you can use the sha256 password and that the default value with pg14.

I use a go program I've found for create this code https://github.com/supercaracal/scram-sha-256/blob/master/main.go

I've add too the test spec test for 2.5.7 (last ruby version of puppet6)