### PR TITLE
Vault expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ We expect storage backends to implement support for the `expires` option, so tha
 
 New backends should be tested using the provided shared example.
 
+> **WARNING**: Vault backend use metadatas. It's set if an option is define. `expire` is automaticly change to `delete_version_after`, and you can use an interger or [format string](https://www.vaultproject.io/api-docs/secret/kv/kv-v2#parameters)
+
 #### Moneta backends
 
 Trocla uses moneta as its default storage backend and hence can store your passwords in any of moneta's supported backends. By default it uses the yaml backend, which is configured as followed:

--- a/lib/trocla.rb
+++ b/lib/trocla.rb
@@ -128,7 +128,7 @@ class Trocla
     else
       raise "Configfile #{@config_file} does not exist!" unless File.exist?(@config_file)
 
-      c = default_config.merge(YAML.safe_load(File.read(@config_file)))
+      c = default_config.merge(YAML.load(File.read(@config_file)))
       c['profiles'] = default_config['profiles'].merge(c['profiles'])
       # migrate all options to new store options
       # TODO: remove workaround in 0.3.0
@@ -159,7 +159,7 @@ class Trocla
 
   def default_config
     require 'yaml'
-    YAML.safe_load(File.read(File.expand_path(File.join(File.dirname(__FILE__), 'trocla', 'default_config.yaml'))))
+    YAML.load(File.read(File.expand_path(File.join(File.dirname(__FILE__), 'trocla', 'default_config.yaml'))))
   end
 
   def merge_profiles(profiles)


### PR DESCRIPTION
Hello,

After testing on a more complex configuration, `YAML.safe_load` not work with symbol, so I revert this change for configuration file for this time.

I also add metadatas support for vault backend, and add a magic trick for `expire` option